### PR TITLE
fix: Resolve package path conflicts between standard and local packages

### DIFF
--- a/executor/add.go
+++ b/executor/add.go
@@ -223,18 +223,12 @@ func (e *Executor) addImportDecl(fileAst *ast.File, pkgNameToImport string) erro
 		return nil
 	}
 
-	// インポートパスの準備
-	var importPathQuoted string
-	if standardPkgName, found := isStandardPackage(pkgNameToImport); found {
-		importPathQuoted = fmt.Sprintf(`"%s"`, standardPkgName)
-	} else {
-		// パッケージパスを探索
-		importPath, err := e.resolveImportPathForAdd(pkgNameToImport)
-		if err != nil {
-			return err
-		}
-		importPathQuoted = fmt.Sprintf(`"%s"`, importPath)
+	// パッケージパスを探索
+	importPath, err := e.resolveImportPathForAdd(pkgNameToImport)
+	if err != nil {
+		return err
 	}
+	importPathQuoted := fmt.Sprintf(`"%s"`, importPath)
 
 	// インポート宣言部分を取得
 	var importGenDecl *ast.GenDecl
@@ -280,6 +274,10 @@ func addBlankAssignStmt(target ast.Expr, list *[]ast.Stmt) {
 func (e *Executor) isFuncVoid(pkgName, funcName string) (bool, error) {
 	targetPkgs, ok := e.astCache.nodes[pkgName]
 	if !ok {
+		if _, ok := isStandardPackage(pkgName); ok {
+			// 標準パッケージの場合はvoidではないと仮定
+			return false, nil
+		}
 		return false, errs.NewInternalError(fmt.Sprintf("package %q not found", pkgName))
 	}
 

--- a/executor/delete.go
+++ b/executor/delete.go
@@ -121,17 +121,15 @@ func extractPkgNameFromPrintlnExprArg(callExpr *ast.CallExpr) string {
 // deleteImportDecl は指定されたパッケージ名のインポート宣言を削除する
 func (e *Executor) deleteImportDecl(file *ast.File, pkgNameToDelete string) error {
 	var importPathQuoteds []string
-	if pkgNameToDelete == "fmt" {
-		importPathQuoteds = append(importPathQuoteds, `"fmt"`)
-	} else {
-		importPaths, err := e.resolveImportPathForDelete(pkgNameToDelete)
-		if err != nil {
-			return err
-		}
-		for _, importPath := range importPaths {
-			importPathQuoteds = append(importPathQuoteds, fmt.Sprintf(`"%s"`, importPath))
-		}
+
+	importPaths, err := e.resolveImportPathForDelete(pkgNameToDelete)
+	if err != nil {
+		return err
 	}
+	for _, importPath := range importPaths {
+		importPathQuoteds = append(importPathQuoteds, fmt.Sprintf(`"%s"`, importPath))
+	}
+
 	for _, decl := range file.Decls {
 		genDecl, ok := decl.(*ast.GenDecl)
 		if !ok || genDecl.Tok != token.IMPORT {
@@ -141,8 +139,9 @@ func (e *Executor) deleteImportDecl(file *ast.File, pkgNameToDelete string) erro
 			importSpec := spec.(*ast.ImportSpec)
 			if slices.Contains(importPathQuoteds, importSpec.Path.Value) {
 				genDecl.Specs = append(genDecl.Specs[:j], genDecl.Specs[j+1:]...)
+				break
 			}
-			break
+			continue
 		}
 	}
 	return nil

--- a/executor/path.go
+++ b/executor/path.go
@@ -31,6 +31,9 @@ func getGoModPath(path string) (string, error) {
 // MEMO: 現状はパッケージ名としてディレクトリ名が一致することを前提としている
 func (e *Executor) resolveImportPathForAdd(pkgName string) (string, error) {
 	var importPaths []string
+	if stdPkg, ok := isStandardPackage(pkgName); ok {
+		importPaths = append(importPaths, stdPkg)
+	}
 	err := filepath.WalkDir(".", func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
@@ -40,6 +43,10 @@ func (e *Executor) resolveImportPathForAdd(pkgName string) (string, error) {
 		}
 		// パッケージ名に一致するディレクトリか？
 		base := filepath.Base(path)
+		if base == "vendor" {
+			// vendorディレクトリはスキップ
+			return filepath.SkipDir
+		}
 		if base == pkgName {
 			relPath, err := filepath.Rel(".", path)
 			if err != nil {
@@ -111,6 +118,9 @@ func toBlue(text string) string {
 // MEMO: 現状はパッケージ名としてディレクトリ名が一致することを前提としている
 func (e *Executor) resolveImportPathForDelete(pkgName string) ([]string, error) {
 	var importPaths []string
+	if stdPkg, ok := isStandardPackage(pkgName); ok {
+		importPaths = append(importPaths, stdPkg)
+	}
 	err := filepath.WalkDir(".", func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err


### PR DESCRIPTION
## Overview

This PR resolves conflicts in package path resolution between standard Go packages and local packages within the project. It refactors the import/delete logic to correctly identify and handle standard packages, preventing incorrect path resolution. Additionally, the `vendor` directory is now skipped during path searches to avoid ambiguity.

## Related Issues

Fixes #10

## Changes

- **executor/add.go**: Modified `addImportDecl` and `isFuncVoid` to correctly handle standard packages, ensuring they are not treated as local packages.
- **executor/delete.go**: Refactored `deleteImportDecl` to use the unified path resolution logic, allowing for the correct deletion of standard package imports.
- **executor/path.go**: Updated `resolveImportPathForAdd` and `resolveImportPathForDelete` to first check if a package is a standard package before searching the local file system. The `vendor` directory is also explicitly skipped to prevent incorrect matches.

## Steps to Verify

- [ ] build project
    - `go build cmd/gonsole/main.go `
- [ ] run the binary in the [example repository](https://github.com/kakkky/gonsole-example)
    - If you don't `git clone` that, please execute bellow command.
        - `git clone https://github.com/kakkky/gonsole-example.git`
- [ ] Try adding and then deleting a standard package like `hash` or `strings`.
- [ ] Verify that the correct import path is added and removed without errors.

## Screenshots (if needed)

N/A

## Checklist

- [ ] Have you run `go test ./...` to ensure the tests pass?
- [ ] Have you confirmed that there are no linter errors? (e.g., `golangci-lint run`)
- [ ] Does this change require updates to the documentation (e.g., README)?
- [ ] Have you performed a self-review of your own code?