### PR TITLE
🐛 Fix method chain from package constructor not producing output

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -264,14 +264,30 @@ func (e *Executor) appendExprStmtToMainFuncBody(exprStmt *ast.ExprStmt, mainFunc
 				return err
 			}
 			pkgName := types.PkgName(selectorBase)
-			funcDeclName := types.DeclName(exprStmtV.Fun.(*ast.SelectorExpr).Sel.Name)
-			var funcSets []symbols.FuncSet
-			if e.symbolIndex != nil {
-				funcSets = e.symbolIndex.Funcs[pkgName]
-			}
-			for _, funcSet := range funcSets {
-				if funcSet.Name == funcDeclName {
-					returnValuesCnt = len(funcSet.Returns)
+			selExpr := exprStmtV.Fun.(*ast.SelectorExpr)
+			declName := types.DeclName(selExpr.Sel.Name)
+			switch selExpr.X.(type) {
+			case *ast.Ident:
+				// 直接のパッケージ関数呼び出し: pkg.Func()
+				var funcSets []symbols.FuncSet
+				if e.symbolIndex != nil {
+					funcSets = e.symbolIndex.Funcs[pkgName]
+				}
+				for _, funcSet := range funcSets {
+					if funcSet.Name == declName {
+						returnValuesCnt = len(funcSet.Returns)
+					}
+				}
+			default:
+				// メソッドチェーン: pkg.Constructor(...).Method()
+				var methodSets []symbols.MethodSet
+				if e.symbolIndex != nil {
+					methodSets = e.symbolIndex.Methods[pkgName]
+				}
+				for _, methodSet := range methodSets {
+					if methodSet.Name == declName {
+						returnValuesCnt = len(methodSet.Returns)
+					}
 				}
 			}
 		}

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -1596,6 +1596,148 @@ func TestExecutor_Execute(t *testing.T) {
 			},
 		},
 		{
+			name:  "call method chain starting from package constructor",
+			input: "pkg.NewObject(\"foo\", 1).ChangeValue(\"bar\").GetValue()",
+			setupDeclRegistry: func(declRegistry *declregistry.DeclRegistry) {
+				// 登録済み変数は存在しない（パッケージから直接チェーン）
+			},
+			setupSymbolIndex: &symbols.SymbolIndex{
+				Methods: map[types.PkgName][]symbols.MethodSet{
+					"pkg": {
+						{
+							Name:             "GetValue",
+							ReceiverTypeName: "Object",
+							Returns:          []symbols.ReturnSet{{TypeName: "string", TypePkgName: ""}},
+						},
+					},
+				},
+			},
+			setupMocks: func(mockFiler *Mockfiler, mockCommander *Mockcommander, mockImportPathResolver *MockimportPathResolver) {
+				setupMocks(t, mockFiler, mockCommander, mockImportPathResolver, "test.go", exprFlush(func(sessionSrcAddedCallExpr *ast.File, targetFile *os.File, fset *token.FileSet) error {
+					expectedSessionSrc := &ast.File{
+						Name: &ast.Ident{Name: "main"},
+						Decls: []ast.Decl{
+							&ast.GenDecl{
+								Tok: token.IMPORT,
+								Specs: []ast.Spec{
+									&ast.ImportSpec{
+										Path: &ast.BasicLit{Kind: token.STRING, Value: `"pkg"`},
+									},
+									&ast.ImportSpec{
+										Path: &ast.BasicLit{Kind: token.STRING, Value: `"github.com/k0kubun/pp/v3"`},
+									},
+								},
+							},
+							&ast.FuncDecl{
+								Name: &ast.Ident{Name: "main"},
+								Type: &ast.FuncType{
+									Params:  &ast.FieldList{List: nil},
+									Results: nil,
+								},
+								Body: &ast.BlockStmt{
+									List: []ast.Stmt{
+										&ast.ExprStmt{
+											X: &ast.CallExpr{
+												Fun: &ast.FuncLit{
+													Type: &ast.FuncType{
+														Params:  &ast.FieldList{List: nil},
+														Results: nil,
+													},
+													Body: &ast.BlockStmt{
+														List: []ast.Stmt{
+															&ast.AssignStmt{
+																Lhs: []ast.Expr{&ast.Ident{Name: "ret0"}},
+																Tok: token.DEFINE,
+																Rhs: []ast.Expr{&ast.CallExpr{
+																	Fun: &ast.SelectorExpr{
+																		X: &ast.CallExpr{
+																			Fun: &ast.SelectorExpr{
+																				X: &ast.CallExpr{
+																					Fun: &ast.SelectorExpr{
+																						X:   &ast.Ident{Name: "pkg"},
+																						Sel: &ast.Ident{Name: "NewObject"},
+																					},
+																					Args: []ast.Expr{
+																						&ast.BasicLit{Kind: token.STRING, Value: `"foo"`},
+																						&ast.BasicLit{Kind: token.INT, Value: "1"},
+																					},
+																				},
+																				Sel: &ast.Ident{Name: "ChangeValue"},
+																			},
+																			Args: []ast.Expr{
+																				&ast.BasicLit{Kind: token.STRING, Value: `"bar"`},
+																			},
+																		},
+																		Sel: &ast.Ident{Name: "GetValue"},
+																	},
+																}},
+															},
+															&ast.ExprStmt{
+																X: &ast.CallExpr{
+																	Fun:  &ast.Ident{Name: "pp.Println"},
+																	Args: []ast.Expr{&ast.Ident{Name: "ret0"}},
+																},
+															},
+														},
+													},
+												},
+												Args: []ast.Expr{},
+											},
+										},
+									},
+								},
+							},
+						},
+						Imports: []*ast.ImportSpec{
+							{Path: &ast.BasicLit{Kind: token.STRING, Value: `"pkg"`}},
+							{Path: &ast.BasicLit{Kind: token.STRING, Value: `"github.com/k0kubun/pp/v3"`}},
+						},
+					}
+
+					cmpOpts := []cmp.Option{
+						cmpopts.IgnoreFields(ast.Ident{}, "Obj", "NamePos"),
+						cmpopts.IgnoreFields(ast.BasicLit{}, "ValuePos"),
+						cmpopts.IgnoreFields(ast.CallExpr{}, "Lparen", "Rparen"),
+						cmpopts.IgnoreFields(ast.FuncLit{}, "Type"),
+						cmpopts.IgnoreFields(ast.FuncType{}, "Func"),
+						cmpopts.IgnoreFields(ast.FieldList{}, "Opening", "Closing"),
+						cmpopts.IgnoreFields(ast.BlockStmt{}, "Lbrace", "Rbrace"),
+						cmpopts.IgnoreFields(ast.AssignStmt{}, "TokPos"),
+					}
+
+					if diff := cmp.Diff(expectedSessionSrc, sessionSrcAddedCallExpr, cmpOpts...); diff != "" {
+						t.Errorf("mismatch (-want +got):\n%s", diff)
+					}
+
+					return nil
+				}),
+					[]byte{}, nil,
+					resolveExpect{types.PkgName("pkg"), types.ImportPath(`"pkg"`)},
+					resolveExpect{types.PkgName("pp"), types.ImportPath(`"github.com/k0kubun/pp/v3"`)},
+				)
+			},
+			expectedSessionSrc: &ast.File{
+				Name: &ast.Ident{Name: "main"},
+				Decls: []ast.Decl{
+					&ast.GenDecl{
+						Tok:   token.IMPORT,
+						Specs: []ast.Spec{},
+					},
+					&ast.FuncDecl{
+						Name: &ast.Ident{Name: "main"},
+						Type: &ast.FuncType{
+							Params:  &ast.FieldList{List: nil},
+							Results: nil,
+						},
+						Body: &ast.BlockStmt{
+							List: []ast.Stmt{},
+						},
+					},
+				},
+				Imports: []*ast.ImportSpec{},
+			},
+		},
+		{
 			name:  "call selector expr of unregistered package",
 			input: "pkg.Var",
 			setupDeclRegistry: func(declRegistry *declregistry.DeclRegistry) {


### PR DESCRIPTION
## Overview

パッケージのコンストラクタから始まるメソッドチェーン（例: `pkg.NewDog(...).ChangeName(...).Describe()`）を呼び出した際に、出力が一切表示されなかったバグを修正した。

## Related Issues

<!-- なし -->

## Changes

- [x] `appendExprStmtToMainFuncBody` の `*ast.CallExpr` ケースにおいて、`selExpr.X` の型で分岐するよう修正
  - `*ast.Ident`（直接のパッケージ関数呼び出し: `pkg.Func()`）→ `symbolIndex.Funcs` で返り値数を検索
  - それ以外（メソッドチェーン: `pkg.New(...).Method()`）→ `symbolIndex.Methods` で返り値数を検索
- [x] 分岐を `if/else` から `switch` に統一
- [x] テストケース追加: `call method chain starting from package constructor`

**バグの原因:**
`pkg.NewDog(...).ChangeName(...).Describe()` をパースすると、最終的な `Fun` は以下の AST になる。

```
SelectorExpr {
  X:   CallExpr(…ChangeName(…))  // *ast.CallExpr
  Sel: "Describe"
}
```

`Describe` はメソッドなので `symbolIndex.Funcs["pkg"]` には存在せず、`returnValuesCnt == 0` → void 扱い → pp ラップなし → 何も出力されない、という問題が発生していた。

## Steps to Verify

- [ ] build project
    - `go build cmd/gonsole/main.go`
- [ ] run the binary in the [example repository](https://github.com/kakkky/gonsole-example)
    - If you don't `git clone` that, please execute bellow command.
        - `git clone https://github.com/kakkky/gonsole-example.git`
- [ ] `pkg.NewDog("peko", 4).ChangeName("pero").Describe()` のようなメソッドチェーンを入力し、出力が表示されることを確認

## Screenshots (if needed)

<!-- 実行例の貼り付けがあると良い -->

## Checklist

- [x] Have you run `go test ./...` to ensure the tests pass?
- [x] Have you confirmed that there are no linter errors? (e.g., `golangci-lint run`)
- [ ] Does this change require updates to the documentation (e.g., README)?
- [x] Have you performed a self-review of your own code?
